### PR TITLE
feat(auth): add mobile login endpoint

### DIFF
--- a/api-banca/app/Http/Controllers/AuthController.php
+++ b/api-banca/app/Http/Controllers/AuthController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    /**
+     * Handle an incoming authentication attempt.
+     */
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $token = $user->createToken('mobile-app')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ]);
+    }
+}

--- a/api-banca/app/Models/User.php
+++ b/api-banca/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/api-banca/bootstrap/app.php
+++ b/api-banca/bootstrap/app.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
+        api: __DIR__.'/../routes/api.php',
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',

--- a/api-banca/routes/api.php
+++ b/api-banca/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+
+Route::post('/login', [AuthController::class, 'login']);


### PR DESCRIPTION
## Summary
- configure app to load API routes and add mobile login endpoint
- use Sanctum tokens for authenticating mobile users

## Testing
- `composer test` *(fails: vendor autoload.php missing)*
- `composer install` *(fails: GitHub 403 requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_6890b0849e7c8328879c5f17657d00ec