### PR TITLE
feat: secure routes and username login

### DIFF
--- a/api-banca/app/Http/Controllers/AuthController.php
+++ b/api-banca/app/Http/Controllers/AuthController.php
@@ -10,17 +10,17 @@ use Illuminate\Support\Facades\Hash;
 class AuthController extends Controller
 {
     /**
-     * Authenticate a user using their client code and password.
+     * Authenticate a user using their username and password.
      */
     public function login(Request $request)
     {
         $credentials = $request->validate([
-            'codigo_cliente' => ['required', 'string'],
+            'name' => ['required', 'string'],
             'password' => ['required'],
         ]);
 
         /** @var User|null $user */
-        $user = User::where('name', $credentials['codigo_cliente'])->first();
+        $user = User::where('name', $credentials['name'])->first();
 
         if (! $user || ! Hash::check($credentials['password'], $user->password)) {
             return response()->json([

--- a/api-banca/app/Models/User.php
+++ b/api-banca/app/Models/User.php
@@ -1,33 +1,58 @@
 <?php
 
-/**
- * Created by Reliese Model.
- */
-
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 /**
  * Class User
- * 
+ *
  * @property int $id
- * @property string $username
+ * @property string $name
+ * @property string $email
+ * @property \Carbon\Carbon|null $email_verified_at
  * @property string $password
+ * @property string|null $remember_token
+ * @property \Carbon\Carbon|null $created_at
+ * @property \Carbon\Carbon|null $updated_at
  *
  * @package App\Models
  */
-class User extends Model
+class User extends Authenticatable
 {
-	protected $table = 'users';
-	public $timestamps = false;
+    use HasApiTokens, HasFactory, Notifiable;
 
-	protected $hidden = [
-		'password'
-	];
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
 
-	protected $fillable = [
-		'username',
-		'password'
-	];
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+    ];
 }
+

--- a/api-banca/routes/api.php
+++ b/api-banca/routes/api.php
@@ -8,12 +8,11 @@ use App\Http\Controllers\CatalogosEconomicosController;
 
 Route::post('/login', [AuthController::class, 'login']);
 
-//rutas Iniciales para MSplusw Virtual Banca
-Route::post('creditos/solicitudes', [CresoliController::class, 'store']);
+// Secure routes for the backend
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('creditos/solicitudes', [CresoliController::class, 'store']);
 
-
-
-
-Route::get('/agencias', [AgenciasController::class, 'index']);
-Route::get('/economia/sectores', [CatalogosEconomicosController::class, 'sectores']);
-Route::get('/economia/sectores/{sectorId}/actividades', [CatalogosEconomicosController::class, 'actividades']);
+    Route::get('/agencias', [AgenciasController::class, 'index']);
+    Route::get('/economia/sectores', [CatalogosEconomicosController::class, 'sectores']);
+    Route::get('/economia/sectores/{sectorId}/actividades', [CatalogosEconomicosController::class, 'actividades']);
+});


### PR DESCRIPTION
## Summary
- authenticate users by `name` and password
- protect API routes with `auth:sanctum`

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689e5057d72083288d042870d0bccf16